### PR TITLE
連続投げに対応できるように処理すべき回数をライブラリで計算する

### DIFF
--- a/bgc.unity.tool/Assets/Scenes/Connect.cs
+++ b/bgc.unity.tool/Assets/Scenes/Connect.cs
@@ -248,13 +248,14 @@ public class Handler : MonoBehaviour
         bool repeatEnd = giftMessage.repeatEnd;
         int giftType = giftMessage.giftType;
         bool isSubscriber = giftMessage.isSubscriber;
+        int executionCount = giftMessage.ExecutionCount;
 
         // ギフトアイコン
         string iconUrl = giftMessage.giftPictureUrl;
         
         // ギフト情報をログに表示（サブスク加入者かどうかも表示）
         string subscriberStatus = isSubscriber ? "【サブスク加入者】" : "";
-        Debug.Log($"🎁 {subscriberStatus}{nickname}さんから{giftName}（ID:{giftId}, {diamondCount}ダイヤ）を{repeatCount}回受け取りました！ repeatEnd: {repeatEnd}, giftType: {giftType}");
+        Debug.Log($"🎁 {subscriberStatus}{nickname}さんから{giftName}（ID:{giftId}, {diamondCount}ダイヤ）を{repeatCount}回受け取りました！ repeatEnd: {repeatEnd}, giftType: {giftType}, executionCount: {executionCount}");
 
         // バラが投げられた時
         if(giftName == "Rose"){
@@ -272,7 +273,14 @@ public class Handler : MonoBehaviour
         
         // ギフトログに追加または更新（サブスク加入者情報も渡す）
         GameObject newGiftItem = AddGiftLogItem(userId, nickname, giftName, giftId, diamondCount, repeatCount, repeatEnd, iconUrl, isSubscriber);
-        
+
+        // 連続投げに対応した実行回数分処理を行う
+        // こちらを使う場合以下のrepeatEndの処理不要
+        for(int i = 0; i < executionCount; i++){
+            // アクションを実行する ログで実行回数を表示
+            Debug.Log($"🎁 実行中 {i + 1}/{executionCount}");
+        }
+
         // repeatEndがtrueの場合の処理
         if (repeatEnd)
         {

--- a/bgc.unity.tool/Packages/bgc.unity.tool/Runtime/Models/TiktokModels.cs
+++ b/bgc.unity.tool/Packages/bgc.unity.tool/Runtime/Models/TiktokModels.cs
@@ -44,6 +44,7 @@ namespace bgc.unity.tool.Models
         public string receiverUserId;
         public string profileName;
         public int combo;
+        public int ExecutionCount;
     }
 
     [Serializable]

--- a/bgc.unity.tool/Packages/bgc.unity.tool/Runtime/bgcTiktokWebSocket.cs
+++ b/bgc.unity.tool/Packages/bgc.unity.tool/Runtime/bgcTiktokWebSocket.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 using bgc.unity.tool.Models;
 using bgc.unity.tool.Services;
 
@@ -65,6 +66,9 @@ namespace bgc.unity.tool
         
         // イベントハンドラが登録済みかどうかのフラグ
         private bool eventHandlersRegistered = false;
+        
+        // コンボ管理用の辞書
+        private Dictionary<string, int> comboMap = new Dictionary<string, int>();
         
         void Awake()
         {
@@ -148,8 +152,51 @@ namespace bgc.unity.tool
         // ギフトメッセージを受信したときの処理
         private void HandleGiftReceived(Models.GiftMessage giftMessage)
         {
-            // 外部のイベントハンドラに転送
+            string key = $"{giftMessage.userId}_{giftMessage.giftId}";
+            
+            int executionCount = UpdateCombo(
+                giftMessage.userId, 
+                giftMessage.giftId.ToString(), 
+                giftMessage.repeatCount, 
+                giftMessage.repeatEnd
+            );
+
+            giftMessage.ExecutionCount = executionCount;
+            
             OnGiftReceived?.Invoke(giftMessage);
+        }
+        
+        private int UpdateCombo(string userId, string giftId, int newCombo, bool isRepeatEnd)
+        {
+            string comboKey = $"{userId}_{giftId}";
+            
+            int currentCombo = 0;
+            comboMap.TryGetValue(comboKey, out currentCombo);
+            
+            if (isRepeatEnd)
+            {
+                if (currentCombo == newCombo)
+                {
+                    comboMap.Remove(comboKey);
+                    return 0;
+                }
+                return 0;
+            }
+            
+            int diff = newCombo - currentCombo;
+            
+            if (diff > 0)
+            {
+                comboMap[comboKey] = newCombo;
+                return diff;
+            }
+            
+            if (isRepeatEnd)
+            {
+                comboMap.Remove(comboKey);
+            }
+
+            return 1;
         }
         
         // 部屋の視聴者情報を受信したときの処理

--- a/bgc.unity.tool/Packages/bgc.unity.tool/package.json
+++ b/bgc.unity.tool/Packages/bgc.unity.tool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bgc.unity.tool",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "displayName": "bgc.unity.tool",
     "description": "bgc.unity.tool",
     "dependencies": {}


### PR DESCRIPTION
```
 int executionCount = giftMessage.ExecutionCount;
```
このようにしてギフトのハンドラーから取得したカウント数実行するだけでまとめ投げに対応できるようになりました。